### PR TITLE
Remove Robolectric `shadows-playservices` dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -126,7 +126,6 @@ protobuf-protoc = { group = "com.google.protobuf", name = "protoc", version.ref 
 protobuf-java-lite = { group = "com.google.protobuf", name = "protobuf-javalite", version.ref = "protobuf" }
 protobuf-kotlin-lite = { group = "com.google.protobuf", name = "protobuf-kotlin-lite", version.ref = "protobuf" }
 robolectric-core = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
-robolectric-playServices = { group = "org.robolectric", name = "shadows-playservices", version.ref = "robolectric" }
 sunriseSunset = { group = "com.luckycatlabs", name = "SunriseSunsetCalculator", version.ref = "sunrise-sunset" }
 testLogger = { group = "com.adarshr", name = "gradle-test-logger-plugin", version.ref = "testLogger" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }


### PR DESCRIPTION
I am going through projects using the `org.robolectric:shadows-playservices` dependency, to see if it is possible to remove it. In this case, it seems to only be declared in the Version Catalog, but not actually used.