### PR TITLE
feat(measurement): enforce finite Distance magnitudes

### DIFF
--- a/core/measurement/src/main/kotlin/io/trewartha/positional/core/measurement/Distance.kt
+++ b/core/measurement/src/main/kotlin/io/trewartha/positional/core/measurement/Distance.kt
@@ -8,8 +8,12 @@ package io.trewartha.positional.core.measurement
  */
 public data class Distance(val magnitude: Double, val unit: Unit) {
 
+    init {
+        require(magnitude.isFinite()) { "Distance magnitude must be finite, but was $magnitude" }
+    }
+
     /**
-     * `true` if the distance is finite, `false` if it is negative or positive infinity
+     * `true` if the distance is finite, `false` if it is NaN or infinite
      */
     val isFinite: Boolean get() = magnitude.isFinite()
 

--- a/core/measurement/src/main/kotlin/io/trewartha/positional/core/measurement/Distance.kt
+++ b/core/measurement/src/main/kotlin/io/trewartha/positional/core/measurement/Distance.kt
@@ -13,11 +13,6 @@ public data class Distance(val magnitude: Double, val unit: Unit) {
     }
 
     /**
-     * `true` if the distance is finite, `false` if it is NaN or infinite
-     */
-    val isFinite: Boolean get() = magnitude.isFinite()
-
-    /**
      * `true` if the distance is negative, `false` if it is positive or zero
      */
     val isNegative: Boolean get() = magnitude < 0.0

--- a/core/measurement/src/main/kotlin/io/trewartha/positional/core/measurement/MgrsCoordinates.kt
+++ b/core/measurement/src/main/kotlin/io/trewartha/positional/core/measurement/MgrsCoordinates.kt
@@ -23,8 +23,8 @@ public data class MgrsCoordinates(
 ) : Coordinates {
 
     private val worldWindMgrsCoordinates = try {
-        require(easting.isFinite && !easting.isNegative) { "Invalid easting: $easting" }
-        require(northing.isFinite && !northing.isNegative) { "Invalid northing: $northing" }
+        require(!easting.isNegative) { "Easting must not be negative but was $easting" }
+        require(!northing.isNegative) { "Northing must not be negative but was $northing" }
         val easting = easting.inRoundedAndPaddedMeters()
         val northing = northing.inRoundedAndPaddedMeters()
         MGRSCoord.fromString("$gridZoneDesignator $gridSquareID $easting $northing")

--- a/core/measurement/src/main/kotlin/io/trewartha/positional/core/measurement/UtmCoordinates.kt
+++ b/core/measurement/src/main/kotlin/io/trewartha/positional/core/measurement/UtmCoordinates.kt
@@ -25,8 +25,8 @@ public data class UtmCoordinates(
             Hemisphere.NORTH -> earth.worldwind.geom.coords.Hemisphere.N
             Hemisphere.SOUTH -> earth.worldwind.geom.coords.Hemisphere.S
         }
-        require(easting.isFinite && !easting.isNegative) { "Invalid easting: $easting" }
-        require(northing.isFinite && !northing.isNegative) { "Invalid northing: $northing" }
+        require(!easting.isNegative) { "Easting must not be negative but was $easting" }
+        require(!northing.isNegative) { "Northing must not be negative but was $northing" }
         val easting = easting.inMeters().magnitude
         val northing = northing.inMeters().magnitude
         UTMCoord.fromUTM(zone, hemisphere, easting, northing)

--- a/core/measurement/src/test/kotlin/io/trewartha/positional/core/measurement/DistanceTest.kt
+++ b/core/measurement/src/test/kotlin/io/trewartha/positional/core/measurement/DistanceTest.kt
@@ -16,7 +16,7 @@ import kotlin.math.abs
 
 class DistanceTest : DescribeSpec({
 
-    describe("instantiating a Distance") {
+    describe("creating a Distance") {
         context("with a finite magnitude") {
             it("succeeds") {
                 checkAll(Arb.numericDouble(), Arb.enum<Distance.Unit>()) { magnitude, unit ->
@@ -61,7 +61,7 @@ class DistanceTest : DescribeSpec({
         }
     }
 
-    describe("checking whether the distance is negative") {
+    describe("whether the distance is negative") {
         context("when the magnitude is negative") {
             it("returns true") {
                 checkAll(
@@ -93,7 +93,7 @@ class DistanceTest : DescribeSpec({
         }
     }
 
-    describe("checking whether the distance is positive") {
+    describe("whether the distance is positive") {
         context("when the magnitude is negative") {
             it("returns false") {
                 checkAll(

--- a/core/measurement/src/test/kotlin/io/trewartha/positional/core/measurement/DistanceTest.kt
+++ b/core/measurement/src/test/kotlin/io/trewartha/positional/core/measurement/DistanceTest.kt
@@ -1,26 +1,53 @@
 package io.trewartha.positional.core.measurement
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.doubles.plusOrMinus
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.enum
 import io.kotest.property.arbitrary.filter
-import io.kotest.property.arbitrary.negativeDouble
 import io.kotest.property.arbitrary.numericDouble
 import io.kotest.property.arbitrary.of
-import io.kotest.property.arbitrary.positiveDouble
 import io.kotest.property.checkAll
 import kotlin.math.abs
 
 class DistanceTest : DescribeSpec({
 
+    describe("instantiating a Distance") {
+        context("with a finite magnitude") {
+            it("succeeds") {
+                checkAll(Arb.numericDouble(), Arb.enum<Distance.Unit>()) { magnitude, unit ->
+                    Distance(magnitude, unit)
+                }
+            }
+        }
+
+        context("with a NaN magnitude") {
+            it("throws IllegalArgumentException") {
+                checkAll(Arb.enum<Distance.Unit>()) { unit ->
+                    shouldThrow<IllegalArgumentException> { Distance(Double.NaN, unit) }
+                }
+            }
+        }
+
+        context("with an infinite magnitude") {
+            it("throws IllegalArgumentException") {
+                checkAll(
+                    Arb.of(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY),
+                    Arb.enum<Distance.Unit>()
+                ) { magnitude, unit ->
+                    shouldThrow<IllegalArgumentException> { Distance(magnitude, unit) }
+                }
+            }
+        }
+    }
+
     describe("creating a distance in feet") {
         it("creates a distance with the correct magnitude and unit") {
-            checkAll(Arb.double()) { number ->
+            checkAll(Arb.numericDouble()) { number ->
                 number.feet.shouldBe(Distance(number, Distance.Unit.FEET))
             }
         }
@@ -28,7 +55,7 @@ class DistanceTest : DescribeSpec({
 
     describe("creating a distance in meters") {
         it("creates a distance with the correct magnitude and unit") {
-            checkAll(Arb.double()) { number ->
+            checkAll(Arb.numericDouble()) { number ->
                 number.meters.shouldBe(Distance(number, Distance.Unit.METERS))
             }
         }
@@ -38,7 +65,7 @@ class DistanceTest : DescribeSpec({
         context("when the magnitude is negative") {
             it("returns true") {
                 checkAll(
-                    Arb.negativeDouble().filter { !it.isNaN() },
+                    Arb.numericDouble().filter { it < 0 },
                     Arb.enum<Distance.Unit>()
                 ) { magnitude, unit ->
                     Distance(magnitude, unit).isNegative.shouldBeTrue()
@@ -57,18 +84,10 @@ class DistanceTest : DescribeSpec({
         context("when the magnitude is positive") {
             it("returns false") {
                 checkAll(
-                    Arb.positiveDouble().filter { !it.isNaN() },
+                    Arb.numericDouble().filter { it > 0 },
                     Arb.enum<Distance.Unit>()
                 ) { magnitude, unit ->
                     Distance(magnitude, unit).isNegative.shouldBeFalse()
-                }
-            }
-        }
-
-        context("when the magnitude is NaN") {
-            it("returns false") {
-                checkAll(Arb.enum<Distance.Unit>()) { unit ->
-                    Distance(Double.NaN, unit).isNegative.shouldBeFalse()
                 }
             }
         }
@@ -78,7 +97,7 @@ class DistanceTest : DescribeSpec({
         context("when the magnitude is negative") {
             it("returns false") {
                 checkAll(
-                    Arb.negativeDouble().filter { !it.isNaN() },
+                    Arb.numericDouble().filter { it < 0 },
                     Arb.enum<Distance.Unit>()
                 ) { magnitude, unit ->
                     Distance(magnitude, unit).isPositive.shouldBeFalse()
@@ -97,50 +116,10 @@ class DistanceTest : DescribeSpec({
         context("when the magnitude is positive") {
             it("returns true") {
                 checkAll(
-                    Arb.positiveDouble().filter { !it.isNaN() },
+                    Arb.numericDouble().filter { it > 0 },
                     Arb.enum<Distance.Unit>()
                 ) { magnitude, unit ->
                     Distance(magnitude, unit).isPositive.shouldBeTrue()
-                }
-            }
-        }
-
-        context("when the magnitude is NaN") {
-            it("returns false") {
-                checkAll(Arb.enum<Distance.Unit>()) { unit ->
-                    Distance(Double.NaN, unit).isPositive.shouldBeFalse()
-                }
-            }
-        }
-    }
-
-    describe("checking whether the distance is finite") {
-        context("when the magnitude is NaN") {
-            it("returns false") {
-                checkAll(Arb.enum<Distance.Unit>()) { unit ->
-                    Distance(Double.NaN, unit).isFinite.shouldBeFalse()
-                }
-            }
-        }
-
-        context("when the magnitude is infinite") {
-            it("returns false") {
-                checkAll(
-                    Arb.of(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY),
-                    Arb.enum<Distance.Unit>()
-                ) { magnitude, unit ->
-                    Distance(magnitude, unit).isFinite.shouldBeFalse()
-                }
-            }
-        }
-
-        context("when the magnitude is finite") {
-            it("returns true") {
-                checkAll(
-                    Arb.numericDouble(),
-                    Arb.enum<Distance.Unit>()
-                ) { magnitude, unit ->
-                    Distance(magnitude, unit).isFinite.shouldBeTrue()
                 }
             }
         }
@@ -149,7 +128,7 @@ class DistanceTest : DescribeSpec({
     describe("converting to feet") {
         context("when the distance is already in feet") {
             it("returns the original distance") {
-                checkAll(Arb.double()) { magnitude ->
+                checkAll(Arb.numericDouble()) { magnitude ->
                     magnitude.feet.inFeet().shouldBe(magnitude.feet)
                 }
             }
@@ -191,7 +170,7 @@ class DistanceTest : DescribeSpec({
 
         context("when the distance is already in meters") {
             it("returns the original distance") {
-                checkAll(Arb.double()) { magnitude ->
+                checkAll(Arb.numericDouble()) { magnitude ->
                     magnitude.meters.inMeters().shouldBe(magnitude.meters)
                 }
             }


### PR DESCRIPTION
## Summary

- Add `init` block to `Distance` that throws `IllegalArgumentException` with a descriptive message when constructed with a NaN or infinite magnitude
- Update `DistanceTest` to cover the new validation (three new cases: finite succeeds, NaN throws, infinite throws)
- Fix all property-based tests that used `Arb.double()` (which can produce non-finite values) to use `Arb.numericDouble()` instead

Closes POS-29

## Test plan

- [ ] `./gradlew :core:measurement:test` passes