### PR TITLE
feat(di): enable generateContributionProviders and make impls internal (POS-39)

### DIFF
--- a/.claude/rules/kotlin/android/dependency-injection.md
+++ b/.claude/rules/kotlin/android/dependency-injection.md
@@ -32,19 +32,23 @@ Anvil-style aggregation and a single `AppScope`.
 
   // For simple interface-to-implementation bindings, use @ContributesBinding on the class:
   @ContributesBinding(AppScope::class)
-  public class MainFooRepository @Inject constructor() : FooRepository {
+  @Inject
+  internal class MainFooRepository() : FooRepository {
       // ...
   }
   ```
-- **Public Visibility for Contributed Types**: All `@ContributesTo` interfaces,
-  `@ContributesBinding` classes, and types they expose must be `public`. Metro's cross-module
-  aggregation cannot access `internal` declarations from other modules.
+- **Visibility for Contributed Types**: `@ContributesTo` interfaces must be `public` since Metro's
+  aggregation requires cross-module access. `@ContributesBinding` and `@ContributesIntoMap` classes
+  should be `internal` — the `generateContributionProviders` feature generates public `@Provides`
+  declarations that expose only the bound type, so the implementation class stays encapsulated.
+  Only keep a contributed class `public` if it is directly referenced from another module (e.g. a
+  ViewModel used cross-module in a Composable).
 - **ViewModel Integration**: ViewModels use `@ContributesIntoMap` with `@ViewModelKey`:
   ```kotlin
   @ContributesIntoMap(AppScope::class)
-  @ViewModelKey(FooViewModel::class)
+  @ViewModelKey
   @Inject
-  public class FooViewModel(
+  internal class FooViewModel(
       fooRepository: FooRepository
   ) : ViewModel()
   ```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.google.services)
     alias(libs.plugins.google.firebase.crashlytics)
-    alias(libs.plugins.metro)
+    id("io.trewartha.positional.metro")
 }
 
 private val PROPERTIES_FILE_PATH = "app/upload_keystore.properties"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:screenOrientation="unspecified"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            tools:ignore="Instantiatable">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/io/trewartha/positional/AppViewModelFactory.kt
+++ b/app/src/main/java/io/trewartha/positional/AppViewModelFactory.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.KClass
 @Inject
 @ContributesBinding(AppScope::class)
 @SingleIn(AppScope::class)
-public class AppViewModelFactory(
+internal class AppViewModelFactory(
     override val viewModelProviders: Map<KClass<out ViewModel>, Provider<ViewModel>>,
     override val assistedFactoryProviders: Map<KClass<out ViewModel>, Provider<ViewModelAssistedFactory>>,
     override val manualAssistedFactoryProviders: Map<KClass<out ManualViewModelAssistedFactory>, Provider<ManualViewModelAssistedFactory>>,

--- a/app/src/main/java/io/trewartha/positional/MainActivity.kt
+++ b/app/src/main/java/io/trewartha/positional/MainActivity.kt
@@ -16,7 +16,7 @@ import io.trewartha.positional.core.ui.format.DateTimeFormatter
 import io.trewartha.positional.core.ui.locals.LocalDateTimeFormatter
 
 @ContributesIntoMap(AppScope::class, binding<Activity>())
-@ActivityKey(MainActivity::class)
+@ActivityKey
 @Inject
 public class MainActivity(
     private val dateTimeFormatter: DateTimeFormatter,

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -22,6 +22,7 @@ tasks.withType<KotlinJvmCompile>().configureEach {
 dependencies {
     compileOnly(libs.android.tools.build)
     compileOnly(libs.kotlin.gradle)
+    implementation(libs.metro.gradle)
     implementation(libs.autonomous.dependencyAnalysis)
     implementation(libs.testLogger.plugin)
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))

--- a/build-logic/convention/src/main/kotlin/io/trewartha/positional/library.android.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/io/trewartha/positional/library.android.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id("io.trewartha.positional.dependencyAnalysis")
+    id("io.trewartha.positional.metro")
     id("io.trewartha.positional.testLogger")
 }
 

--- a/build-logic/convention/src/main/kotlin/io/trewartha/positional/library.jvm.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/io/trewartha/positional/library.jvm.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm")
     id("io.trewartha.positional.testFixtures.jvm")
     id("io.trewartha.positional.dependencyAnalysis")
+    id("io.trewartha.positional.metro")
     id("io.trewartha.positional.testLogger")
 }
 

--- a/build-logic/convention/src/main/kotlin/io/trewartha/positional/metro.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/io/trewartha/positional/metro.gradle.kts
@@ -1,0 +1,12 @@
+package io.trewartha.positional
+
+import dev.zacsweers.metro.gradle.MetroPluginExtension
+
+pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+    apply(plugin = "dev.zacsweers.metro")
+    configure<MetroPluginExtension> { generateContributionProviders.set(true) }
+}
+pluginManager.withPlugin("org.jetbrains.kotlin.android") {
+    apply(plugin = "dev.zacsweers.metro")
+    configure<MetroPluginExtension> { generateContributionProviders.set(true) }
+}

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.positional.library.android)
     alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.metro)
 }
 
 android {

--- a/core/ui/src/main/kotlin/io/trewartha/positional/core/ui/format/SystemDateTimeFormatter.kt
+++ b/core/ui/src/main/kotlin/io/trewartha/positional/core/ui/format/SystemDateTimeFormatter.kt
@@ -21,7 +21,7 @@ import kotlinx.datetime.toLocalDateTime
 
 @ContributesBinding(AppScope::class)
 @Inject
-public class SystemDateTimeFormatter(locale: Locale) : DateTimeFormatter {
+internal class SystemDateTimeFormatter(locale: Locale) : DateTimeFormatter {
 
     private val dateFormat = SimpleDateFormat.getDateInstance(MEDIUM)
     private val dateTimeFormat = SimpleDateFormat.getDateTimeInstance(MEDIUM, SHORT)

--- a/feature/compass/build.gradle.kts
+++ b/feature/compass/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.positional.library.android)
-    alias(libs.plugins.metro)
 }
 
 android {

--- a/feature/compass/ui/build.gradle.kts
+++ b/feature/compass/ui/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.positional.library.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.metro)
 }
 
 android {

--- a/feature/compass/ui/src/main/kotlin/io/trewartha/positional/compass/ui/CompassViewModel.kt
+++ b/feature/compass/ui/src/main/kotlin/io/trewartha/positional/compass/ui/CompassViewModel.kt
@@ -23,9 +23,9 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 
 @ContributesIntoMap(AppScope::class)
-@ViewModelKey(CompassViewModel::class)
+@ViewModelKey
 @Inject
-public class CompassViewModel(
+internal class CompassViewModel(
     compass: Compass?,
     locator: Locator,
     settings: SettingsRepository

--- a/feature/location/build.gradle.kts
+++ b/feature/location/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.positional.library.android)
-    alias(libs.plugins.metro)
 }
 
 android {

--- a/feature/location/src/gms/kotlin/io/trewartha/positional/location/GmsLocator.kt
+++ b/feature/location/src/gms/kotlin/io/trewartha/positional/location/GmsLocator.kt
@@ -33,7 +33,7 @@ import kotlin.coroutines.CoroutineContext
 @ContributesBinding(AppScope::class)
 @SingleIn(AppScope::class)
 @Inject
-public class GmsLocator(
+internal class GmsLocator(
     private val fusedLocationProviderClient: FusedLocationProviderClient,
     private val fallbackAospLocator: AospLocator,
     private val coroutineContext: CoroutineContext = Dispatchers.Default

--- a/feature/location/ui/build.gradle.kts
+++ b/feature/location/ui/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.positional.library.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.metro)
 }
 
 android {

--- a/feature/location/ui/src/main/kotlin/io/trewartha/positional/location/ui/LocationViewModel.kt
+++ b/feature/location/ui/src/main/kotlin/io/trewartha/positional/location/ui/LocationViewModel.kt
@@ -18,9 +18,9 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 
 @ContributesIntoMap(AppScope::class)
-@ViewModelKey(LocationViewModel::class)
+@ViewModelKey
 @Inject
-public class LocationViewModel(
+internal class LocationViewModel(
     locator: Locator,
     settings: SettingsRepository
 ) : ViewModel() {

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.positional.library.android)
-    alias(libs.plugins.metro)
     alias(libs.plugins.wire)
 }
 

--- a/feature/settings/src/main/kotlin/io/trewartha/positional/settings/DataStoreSettingsRepository.kt
+++ b/feature/settings/src/main/kotlin/io/trewartha/positional/settings/DataStoreSettingsRepository.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.flow.map
 @ContributesBinding(AppScope::class)
 @SingleIn(AppScope::class)
 @Inject
-public class DataStoreSettingsRepository(
+internal class DataStoreSettingsRepository(
     private val application: Application
 ) : SettingsRepository {
 

--- a/feature/settings/ui/build.gradle.kts
+++ b/feature/settings/ui/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.positional.library.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.metro)
 }
 
 android {

--- a/feature/settings/ui/src/main/kotlin/io/trewartha/positional/settings/ui/SettingsViewModel.kt
+++ b/feature/settings/ui/src/main/kotlin/io/trewartha/positional/settings/ui/SettingsViewModel.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 @ContributesIntoMap(AppScope::class)
-@ViewModelKey(SettingsViewModel::class)
+@ViewModelKey
 @Inject
 public class SettingsViewModel(
     private val settingsRepository: SettingsRepository

--- a/feature/sun/build.gradle.kts
+++ b/feature/sun/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.positional.library.jvm)
-    alias(libs.plugins.metro)
 }
 
 dependencies {

--- a/feature/sun/src/main/kotlin/io/trewartha/positional/sun/MainSolarTimesRepository.kt
+++ b/feature/sun/src/main/kotlin/io/trewartha/positional/sun/MainSolarTimesRepository.kt
@@ -16,7 +16,7 @@ import kotlinx.datetime.LocalTime
  */
 @ContributesBinding(AppScope::class)
 @Inject
-public class MainSolarTimesRepository() : SolarTimesRepository {
+internal class MainSolarTimesRepository() : SolarTimesRepository {
 
     override fun getAstronomicalDawn(coordinates: Coordinates, date: LocalDate): LocalTime? =
         createLibraryCalculator(coordinates)

--- a/feature/sun/ui/build.gradle.kts
+++ b/feature/sun/ui/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.positional.library.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.metro)
 }
 
 android {

--- a/feature/sun/ui/src/main/kotlin/io/trewartha/positional/sun/ui/SunViewModel.kt
+++ b/feature/sun/ui/src/main/kotlin/io/trewartha/positional/sun/ui/SunViewModel.kt
@@ -34,9 +34,9 @@ import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 
 @ContributesIntoMap(AppScope::class)
-@ViewModelKey(SunViewModel::class)
+@ViewModelKey
 @Inject
-public class SunViewModel(
+internal class SunViewModel(
     private val clock: Clock,
     locator: Locator,
     private val solarTimesRepository: SolarTimesRepository

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -117,6 +117,7 @@ kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime",
 kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
 markwon = { group = "io.noties.markwon", name = "core", version.ref = "markwon" }
 metro-android = { group = "dev.zacsweers.metro", name = "metrox-android", version.ref = "metro" }
+metro-gradle = { group = "dev.zacsweers.metro", name = "gradle-plugin", version.ref = "metro" }
 metro-runtime = { group = "dev.zacsweers.metro", name = "metro-runtime", version.ref = "metro" }
 metro-viewModel = { group = "dev.zacsweers.metro", name = "metrox-viewmodel", version.ref = "metro" }
 metro-viewModel-compose = { group = "dev.zacsweers.metro", name = "metrox-viewmodel-compose", version.ref = "metro" }


### PR DESCRIPTION
## Summary
- Enable Metro 0.13's `generateContributionProviders` via a new `io.trewartha.positional.metro` convention plugin, applied from both library convention plugins (and directly from `app`).
- Flip 8 `@ContributesBinding` / `@ContributesIntoMap` implementation classes from `public` to `internal` — the generated providers expose only the bound type, so the impl can stay encapsulated.
- Adopt Metro 0.12+ implicit class keys: drop the redundant `::class` args from `@ViewModelKey` and `@ActivityKey` across the 4 ViewModels and `MainActivity`.
- Update the DI rules doc to reflect the new `internal`-by-default guidance and implicit-key examples.

`SettingsViewModel` stays `public` — it's referenced cross-module from `app/MainView.kt` via `metroViewModel()`.

Closes POS-39. Supersedes #614 (which bundled the now-merged POS-38 Metro bump with this work on a stranded branch).

## Test plan
- [x] `./gradlew assembleAospDebug assembleGmsDebug` — DI graph resolves the now-`internal` bindings
- [x] `./gradlew test` — all unit tests pass across every flavor
- [ ] Smoke test the Compass / Location / Sun / Settings screens on AOSP + GMS flavors on a device

🤖 Generated with [Claude Code](https://claude.com/claude-code)