### PR TITLE
build: upgrade to AGP 9.1.1 (POS-31)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,6 @@ import org.jetbrains.kotlin.konan.properties.loadProperties
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.google.services)
@@ -123,13 +122,13 @@ dependencies {
 kotlin {
     compilerOptions {
         freeCompilerArgs.addAll(
-            "-Xjvm-default=all",
-            "-Xinline-classes",
+            "-jvm-default=no-compatibility",
         )
         jvmTarget = JvmTarget.JVM_21
         optIn.addAll(
             "androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi",
             "com.google.accompanist.permissions.ExperimentalPermissionsApi",
+            "kotlin.ExperimentalStdlibApi",
             "kotlin.time.ExperimentalTime",
         )
     }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -16,6 +16,7 @@ tasks.withType<KotlinJvmCompile>().configureEach {
     compilerOptions {
         jvmTarget = JvmTarget.JVM_21
         freeCompilerArgs.add("-Xcontext-parameters")
+        optIn.add("dev.zacsweers.metro.gradle.ExperimentalMetroGradleApi")
     }
 }
 

--- a/build-logic/convention/src/main/kotlin/io/trewartha/positional/KotlinConfigurationConstants.kt
+++ b/build-logic/convention/src/main/kotlin/io/trewartha/positional/KotlinConfigurationConstants.kt
@@ -7,8 +7,11 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 val EXPLICIT_API_MODE = ExplicitApiMode.Strict
 
 val FREE_COMPILER_ARGS = listOf(
-    "-Xinline-classes",
-    "-Xjvm-default=all",
+    "-jvm-default=no-compatibility",
+)
+
+val GLOBAL_OPT_INS = listOf(
+    "kotlin.ExperimentalStdlibApi",
 )
 
 val JVM_SOURCE_COMPATIBILITY = JavaVersion.VERSION_21

--- a/build-logic/convention/src/main/kotlin/io/trewartha/positional/library.android.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/io/trewartha/positional/library.android.gradle.kts
@@ -6,7 +6,6 @@ val libs = the<LibrariesForLibs>()
 
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
     id("io.trewartha.positional.dependencyAnalysis")
     id("io.trewartha.positional.metro")
     id("io.trewartha.positional.testLogger")
@@ -108,6 +107,7 @@ kotlin {
     compilerOptions {
         freeCompilerArgs.addAll(FREE_COMPILER_ARGS)
         jvmTarget = JVM_TARGET
+        optIn.addAll(GLOBAL_OPT_INS)
     }
     explicitApi = EXPLICIT_API_MODE
 }

--- a/build-logic/convention/src/main/kotlin/io/trewartha/positional/library.jvm.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/io/trewartha/positional/library.jvm.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
     compilerOptions {
         freeCompilerArgs.addAll(FREE_COMPILER_ARGS)
         jvmTarget = JVM_TARGET
+        optIn.addAll(GLOBAL_OPT_INS)
     }
     explicitApi = EXPLICIT_API_MODE
 }

--- a/build-logic/convention/src/main/kotlin/io/trewartha/positional/metro.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/io/trewartha/positional/metro.gradle.kts
@@ -2,11 +2,11 @@ package io.trewartha.positional
 
 import dev.zacsweers.metro.gradle.MetroPluginExtension
 
-pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+val applyMetro: () -> Unit = {
     apply(plugin = "dev.zacsweers.metro")
     configure<MetroPluginExtension> { generateContributionProviders.set(true) }
 }
-pluginManager.withPlugin("org.jetbrains.kotlin.android") {
-    apply(plugin = "dev.zacsweers.metro")
-    configure<MetroPluginExtension> { generateContributionProviders.set(true) }
-}
+
+pluginManager.withPlugin("org.jetbrains.kotlin.jvm") { applyMetro() }
+pluginManager.withPlugin("com.android.library") { applyMetro() }
+pluginManager.withPlugin("com.android.application") { applyMetro() }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     // that).
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
 
     alias(libs.plugins.autonomous.dependencyAnalysis)

--- a/core/ui/src/main/kotlin/io/trewartha/positional/core/ui/Color.kt
+++ b/core/ui/src/main/kotlin/io/trewartha/positional/core/ui/Color.kt
@@ -1,6 +1,8 @@
 package io.trewartha.positional.core.ui
 
 import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 
 public val md_theme_light_primary: Color = Color(0xFF005AC1)
@@ -75,7 +77,7 @@ public val md_theme_dark_sunset: Color = Color(0x4DFFDBA6)
 
 public val seed: Color = Color(0xFF4285F4)
 
-public val lightColorScheme: ColorScheme = ColorScheme(
+public val lightColorScheme: ColorScheme = lightColorScheme(
     primary = md_theme_light_primary,
     onPrimary = md_theme_light_onPrimary,
     primaryContainer = md_theme_light_primaryContainer,
@@ -107,7 +109,7 @@ public val lightColorScheme: ColorScheme = ColorScheme(
     scrim = md_theme_light_scrim
 )
 
-public val darkColorScheme: ColorScheme = ColorScheme(
+public val darkColorScheme: ColorScheme = darkColorScheme(
     primary = md_theme_dark_primary,
     onPrimary = md_theme_dark_onPrimary,
     primaryContainer = md_theme_dark_primaryContainer,

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,6 @@ org.gradle.jvmargs=-Xmx4196M -Dkotlin.daemon.jvm.options\="-Xmx4196M"
 org.gradle.parallel=true
 android.experimental.enableTestFixturesKotlinSupport=true
 android.r8.optimizedResourceShrinking=true
+android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarnings,android.experimental.enableTestFixturesKotlinSupport,android.testoptions.manageddevices.emulator.gpu
 android.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
 android.useAndroidX=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 accompanist = "0.37.3"
 android-tools-common = "36.1.0"
 android-tools-desugarJdkLibs = "2.1.5"
-android-tools-gradle = "8.13.2"
+android-tools-gradle = "9.1.1"
 androidx-activity = "1.11.0"
 androidx-activity-compose = "1.11.0"
 androidx-appcompat = "1.7.1"
@@ -50,7 +50,6 @@ android-library = { id = "com.android.library", version.ref = "android-tools-gra
 autonomous-dependencyAnalysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "autonomous-dependencyAnalysis" }
 google-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "google-firebase-crashlytics-gradle" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- Upgrades Android Gradle Plugin to 9.1.1, which drops the standalone `org.jetbrains.kotlin.android` plugin in favor of AGP's built-in Kotlin (removed from `libs.versions.toml`, root build script, `app`, and `library.android` convention plugin).
- Migrates Kotlin compiler flags away from deprecated `-X` prefixes: `-Xjvm-default=all` → `-jvm-default=no-compatibility`, and drops the redundant `-Xinline-classes`.
- Replaces the deprecated `ColorScheme(...)` constructor in `core/ui` with the `lightColorScheme`/`darkColorScheme` factories so the new `surfaceContainer` roles get sensible defaults.
- Adds global Kotlin opt-ins via the DSL: `kotlin.ExperimentalStdlibApi` for every Kotlin module (shared through `GLOBAL_OPT_INS` in the convention plugins) and `dev.zacsweers.metro.gradle.ExperimentalMetroGradleApi` for build-logic so `generateContributionProviders` can be configured without warnings.
- Suppresses noisy unsupported-option warnings in `gradle.properties`.

## Test plan
- [ ] `./gradlew build` succeeds with no deprecation/experimental warnings on the changed surfaces
- [ ] `./gradlew test` passes across all flavors
- [ ] App builds and launches on a Pixel device with both `aosp` and `gms` flavors

🤖 Generated with [Claude Code](https://claude.com/claude-code)