### PR TITLE
ci: rename tests workflow to CI and run all checks (POS-45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
-name: Tests
+name: CI
 on:
   pull_request:
   push:
     branches:
       - 'main'
 jobs:
-  unit_tests:
-    name: 'Unit tests'
+  checks:
+    name: 'Checks'
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out the repository'
@@ -26,11 +26,11 @@ jobs:
         with:
           log-accepted-android-sdk-licenses: false
 
-      - name: 'Run unit tests'
+      - name: 'Run checks w/ test coverage reports'
         run: >-
-          ./gradlew test koverXmlReport
+          ./gradlew check koverXmlReport
 
-      - name: 'Upload coverage report to Codecov'
+      - name: 'Upload test coverage reports to Codecov'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Renames the `Tests` workflow to `CI` (file `tests.yml` → `ci.yml`, job `unit_tests` → `checks`).
- Swaps `./gradlew test` for `./gradlew check` so lint/Detekt and other verification tasks run alongside unit tests.
- Updates the Codecov step label to reflect that coverage comes from the broader `check` run.

## Test plan
- [ ] GitHub Actions `CI / Checks` job runs on this PR and completes successfully.
- [ ] Codecov upload succeeds with coverage from `koverXmlReport`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)