### PR TITLE
build: remove test-logger Gradle plugin (POS-46)

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
     compileOnly(libs.kotlin.gradle)
     implementation(libs.metro.gradle)
     implementation(libs.autonomous.dependencyAnalysis)
-    implementation(libs.testLogger.plugin)
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }
 

--- a/build-logic/convention/src/main/kotlin/io/trewartha/positional/library.android.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/io/trewartha/positional/library.android.gradle.kts
@@ -8,7 +8,6 @@ plugins {
     id("com.android.library")
     id("io.trewartha.positional.dependencyAnalysis")
     id("io.trewartha.positional.metro")
-    id("io.trewartha.positional.testLogger")
 }
 
 android {

--- a/build-logic/convention/src/main/kotlin/io/trewartha/positional/library.jvm.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/io/trewartha/positional/library.jvm.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     id("io.trewartha.positional.testFixtures.jvm")
     id("io.trewartha.positional.dependencyAnalysis")
     id("io.trewartha.positional.metro")
-    id("io.trewartha.positional.testLogger")
 }
 
 java {

--- a/build-logic/convention/src/main/kotlin/io/trewartha/positional/testLogger.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/io/trewartha/positional/testLogger.gradle.kts
@@ -1,9 +1,0 @@
-package io.trewartha.positional
-
-plugins {
-    id("com.adarshr.test-logger")
-}
-
-testlogger {
-    setTheme("mocha")
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,6 @@ markwon = "4.6.2"
 metro = "0.13.2"
 robolectric = "4.16.1"
 sunrise-sunset = "1.2"
-testLogger-plugin = "4.0.0"
 timber = "5.0.1"
 turbine = "1.2.1"
 wire = "6.2.0"
@@ -123,7 +122,6 @@ metro-viewModel-compose = { group = "dev.zacsweers.metro", name = "metrox-viewmo
 robolectric-core = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 wire-runtime = { group = "com.squareup.wire", name = "wire-runtime", version.ref = "wire" }
 sunriseSunset = { group = "com.luckycatlabs", name = "SunriseSunsetCalculator", version.ref = "sunrise-sunset" }
-testLogger-plugin = { group = "com.adarshr", name = "gradle-test-logger-plugin", version.ref = "testLogger-plugin" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 worldwind = { group = "earth.worldwind", name = "worldwind", version.ref = "worldwind" }


### PR DESCRIPTION
## Summary
- Removes the `com.adarshr.test-logger` Gradle plugin (noisy per [POS-46](https://linear.app/trewartha/issue/POS-46/remove-the-test-logging-gradle-plugin)); tests now use Gradle's default reporting.
- Drops the `testLogger` convention plugin and its application from `library.jvm` and `library.android`.
- Removes the plugin dependency from `build-logic` and both catalog entries from `gradle/libs.versions.toml`.

## Test plan
- [x] `./gradlew help` — configuration resolves cleanly with no missing plugin references.
- [x] `./gradlew test` — all unit tests pass across aosp/gms × debug/release flavors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)