### PR TITLE
test(core:ui): add unit tests for SystemDateTimeFormatter (POS-58)

### DIFF
--- a/app/src/main/java/io/trewartha/positional/AppProviders.kt
+++ b/app/src/main/java/io/trewartha/positional/AppProviders.kt
@@ -9,6 +9,7 @@ import java.util.Locale
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Clock
 import kotlinx.coroutines.Dispatchers
+import kotlinx.datetime.TimeZone
 
 @ContributesTo(AppScope::class)
 public interface AppProviders {
@@ -21,6 +22,9 @@ public interface AppProviders {
 
     @Provides
     fun locale(): Locale = checkNotNull(LocaleListCompat.getDefault()[0])
+
+    @Provides
+    fun timeZone(): TimeZone = TimeZone.currentSystemDefault()
 
     @Provides
     fun windowManager(application: Application): WindowManager =

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(libs.markwon)
 
     testImplementation(projects.core.test)
+    testImplementation(libs.kotest.property)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation(libs.kotlinx.datetime)
     implementation(libs.markwon)
 
+    testImplementation(projects.core.test)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
 }

--- a/core/ui/src/main/kotlin/io/trewartha/positional/core/ui/format/SystemDateTimeFormatter.kt
+++ b/core/ui/src/main/kotlin/io/trewartha/positional/core/ui/format/SystemDateTimeFormatter.kt
@@ -17,17 +17,28 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atDate
 import kotlinx.datetime.atTime
 import kotlinx.datetime.toInstant
+import kotlinx.datetime.toJavaZoneId
 import kotlinx.datetime.toLocalDateTime
 
 @ContributesBinding(AppScope::class)
 @Inject
-internal class SystemDateTimeFormatter(locale: Locale) : DateTimeFormatter {
+internal class SystemDateTimeFormatter(
+    private val clock: Clock,
+    locale: Locale,
+    private val timeZone: TimeZone,
+) : DateTimeFormatter {
 
-    private val dateFormat = SimpleDateFormat.getDateInstance(MEDIUM)
-    private val dateTimeFormat = SimpleDateFormat.getDateTimeInstance(MEDIUM, SHORT)
+    private val javaTimeZone = java.util.TimeZone.getTimeZone(timeZone.toJavaZoneId())
+    private val dateFormat = SimpleDateFormat.getDateInstance(MEDIUM, locale)
+        .also { it.timeZone = javaTimeZone }
+    private val dateTimeFormat = SimpleDateFormat.getDateTimeInstance(MEDIUM, SHORT, locale)
+        .also { it.timeZone = javaTimeZone }
     private val fullDayOfWeekFormat = SimpleDateFormat("EEEE", locale)
-    private val timeFormat = SimpleDateFormat.getTimeInstance(SHORT)
-    private val timeFormatWithSeconds = SimpleDateFormat.getTimeInstance(MEDIUM)
+        .also { it.timeZone = javaTimeZone }
+    private val timeFormat = SimpleDateFormat.getTimeInstance(SHORT, locale)
+        .also { it.timeZone = javaTimeZone }
+    private val timeFormatWithSeconds = SimpleDateFormat.getTimeInstance(MEDIUM, locale)
+        .also { it.timeZone = javaTimeZone }
 
     override fun formatDate(localDate: LocalDate): String =
         dateFormat.format(localDate.toJavaDate())
@@ -39,8 +50,7 @@ internal class SystemDateTimeFormatter(locale: Locale) : DateTimeFormatter {
         fullDayOfWeekFormat.format(localDate.toJavaDate())
 
     override fun formatTime(localTime: LocalTime, includeSeconds: Boolean): String {
-        val timeZone = TimeZone.currentSystemDefault()
-        val today = Clock.System.now().toLocalDateTime(timeZone).date
+        val today = clock.now().toLocalDateTime(timeZone).date
         val javaDate = localTime.atDate(today).toInstant(timeZone).toJavaDate()
         return if (includeSeconds) {
             timeFormatWithSeconds.format(javaDate)
@@ -50,12 +60,12 @@ internal class SystemDateTimeFormatter(locale: Locale) : DateTimeFormatter {
     }
 
     private fun LocalDate.toInstant(): Instant =
-        atTime(0, 0).toInstant(TimeZone.currentSystemDefault())
+        atTime(0, 0).toInstant(timeZone)
 
     private fun LocalDate.toJavaDate(): Date = toInstant().toJavaDate()
 
     private fun LocalDateTime.toJavaDate(): Date =
-        toInstant(TimeZone.currentSystemDefault()).toJavaDate()
+        toInstant(timeZone).toJavaDate()
 
     private fun Instant.toJavaDate(): Date = Date(toEpochMilliseconds())
 }

--- a/core/ui/src/test/kotlin/io/trewartha/positional/core/ui/format/SystemDateTimeFormatterTest.kt
+++ b/core/ui/src/test/kotlin/io/trewartha/positional/core/ui/format/SystemDateTimeFormatterTest.kt
@@ -4,6 +4,9 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
+import io.kotest.property.Exhaustive
+import io.kotest.property.checkAll
+import io.kotest.property.exhaustive.collection
 import io.trewartha.positional.core.test.FakeClock
 import java.util.Locale
 import kotlin.time.Clock
@@ -38,21 +41,21 @@ class SystemDateTimeFormatterTest : DescribeSpec({
     }
 
     describe("formatting the full day of the week") {
-        context("for a Monday") {
-            it("returns 'Monday'") {
-                sut().formatFullDayOfWeek(LocalDate(2024, 1, 15)).shouldBe("Monday")
-            }
-        }
-
-        context("for a Wednesday") {
-            it("returns 'Wednesday'") {
-                sut().formatFullDayOfWeek(LocalDate(2024, 1, 17)).shouldBe("Wednesday")
-            }
-        }
-
-        context("for a Sunday") {
-            it("returns 'Sunday'") {
-                sut().formatFullDayOfWeek(LocalDate(2024, 1, 21)).shouldBe("Sunday")
+        it("returns the full English name of the day") {
+            checkAll(
+                Exhaustive.collection(
+                    listOf(
+                        LocalDate(2024, 1, 15) to "Monday",
+                        LocalDate(2024, 1, 16) to "Tuesday",
+                        LocalDate(2024, 1, 17) to "Wednesday",
+                        LocalDate(2024, 1, 18) to "Thursday",
+                        LocalDate(2024, 1, 19) to "Friday",
+                        LocalDate(2024, 1, 20) to "Saturday",
+                        LocalDate(2024, 1, 21) to "Sunday",
+                    )
+                )
+            ) { (date, expectedDayName) ->
+                sut().formatFullDayOfWeek(date).shouldBe(expectedDayName)
             }
         }
     }

--- a/core/ui/src/test/kotlin/io/trewartha/positional/core/ui/format/SystemDateTimeFormatterTest.kt
+++ b/core/ui/src/test/kotlin/io/trewartha/positional/core/ui/format/SystemDateTimeFormatterTest.kt
@@ -1,0 +1,75 @@
+package io.trewartha.positional.core.ui.format
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.trewartha.positional.core.test.FakeClock
+import java.util.Locale
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+
+// Java 21 CLDR data uses U+202F (narrow no-break space) before AM/PM indicators in en-US locale
+private const val NNBSP = ' '
+
+class SystemDateTimeFormatterTest : DescribeSpec({
+
+    fun sut(
+        clock: Clock = FakeClock(Instant.fromEpochMilliseconds(0)),
+        locale: Locale = Locale.US,
+        timeZone: TimeZone = TimeZone.UTC,
+    ): SystemDateTimeFormatter = SystemDateTimeFormatter(clock, locale, timeZone)
+
+    describe("formatting a date") {
+        it("returns the date in medium format") {
+            sut().formatDate(LocalDate(2024, 1, 15)).shouldBe("Jan 15, 2024")
+        }
+    }
+
+    describe("formatting a date and time") {
+        it("returns the date and time in medium date and short time format") {
+            sut().formatDateTime(LocalDateTime(2024, 1, 15, 11, 22, 0))
+                .shouldBe("Jan 15, 2024, 11:22${NNBSP}AM")
+        }
+    }
+
+    describe("formatting the full day of the week") {
+        context("for a Monday") {
+            it("returns 'Monday'") {
+                sut().formatFullDayOfWeek(LocalDate(2024, 1, 15)).shouldBe("Monday")
+            }
+        }
+
+        context("for a Wednesday") {
+            it("returns 'Wednesday'") {
+                sut().formatFullDayOfWeek(LocalDate(2024, 1, 17)).shouldBe("Wednesday")
+            }
+        }
+
+        context("for a Sunday") {
+            it("returns 'Sunday'") {
+                sut().formatFullDayOfWeek(LocalDate(2024, 1, 21)).shouldBe("Sunday")
+            }
+        }
+    }
+
+    describe("formatting a time") {
+        context("when seconds are not requested") {
+            it("omits seconds from the result") {
+                sut().formatTime(LocalTime(11, 22, 33), includeSeconds = false)
+                    .shouldNotContain(":33")
+            }
+        }
+
+        context("when seconds are requested") {
+            it("includes seconds in the result") {
+                sut().formatTime(LocalTime(11, 22, 33), includeSeconds = true)
+                    .shouldContain(":33")
+            }
+        }
+    }
+})


### PR DESCRIPTION
## Summary

- Inject `Clock` and `TimeZone` into `SystemDateTimeFormatter` so the class is fully testable without relying on global JVM state (`Clock.System` and `TimeZone.currentSystemDefault()`)
- Thread the injected `locale` through to all `SimpleDateFormat` instances — previously only `fullDayOfWeekFormat` received it, leaving the others at the JVM default
- Add a `timeZone(): TimeZone` provider to `AppProviders`
- Add `SystemDateTimeFormatterTest` with DescribeSpec-style coverage for all four formatter methods

## Test plan

- [ ] `formatting a date` — verifies medium-format date output (`Jan 15, 2024`)
- [ ] `formatting a date and time` — verifies medium-date + short-time output
- [ ] `formatting the full day of the week` — verifies English day names for Monday, Wednesday, and Sunday
- [ ] `formatting a time / when seconds are not requested` — verifies seconds are omitted from SHORT format
- [ ] `formatting a time / when seconds are requested` — verifies seconds are present in MEDIUM format
- [ ] Run `:core:ui:testGmsDebugUnitTest` to confirm all tests pass

https://claude.ai/code/session_016Eu54qaDDroj3tKDZtsvhA

---
_Generated by [Claude Code](https://claude.ai/code/session_016Eu54qaDDroj3tKDZtsvhA)_